### PR TITLE
[FIX] Tailwind grid class for React template

### DIFF
--- a/templates/react-eslint-ts-tw/project/src/App.tsx
+++ b/templates/react-eslint-ts-tw/project/src/App.tsx
@@ -1,6 +1,6 @@
 function App() {
   return (
-    <main className="container m-auto grid min-h-screen grid-rows-[auto,1fr,auto] px-4">
+    <main className="container m-auto grid min-h-screen grid-rows-[auto_1fr_auto] px-4">
       <header className="text-xl leading-[4rem] font-bold">{{name}}</header>
       <section className="py-8">👋</section>
       <footer className="text-center leading-[4rem] opacity-70">


### PR DESCRIPTION
## Fix tailwind grid class

As indicated in the Tailwind [documentation](https://tailwindcss.com/docs/adding-custom-styles#handling-whitespace), properties containing a space (" ") should use an underscore ("_"). This issue is only present in the React template.

### Before

I only added white borders to make the grid more visible and easier to identify the problem, they were not applied.

![image](https://github.com/user-attachments/assets/d163986e-261e-44d0-b103-5554b8d9fee7)

### After

![image](https://github.com/user-attachments/assets/de12c152-6f9a-437c-9bd1-d4d0b596a9b1)
